### PR TITLE
INTLY-1362 Allow managedServices to be specified in JSON config

### DIFF
--- a/bin/resources/schema.json
+++ b/bin/resources/schema.json
@@ -19,6 +19,25 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "managedServices": {
+          "$id": "#/properties/dependencies/properties/managedServices",
+          "type": "array",
+          "title": "The Managed Services Schema",
+          "items": {
+            "$id": "#/properies/dependencies/properties/managedServices/items",
+            "type": "object",
+            "title": "The Items Schema",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "$id": "#/properties/dependencies/properties/managedServices/items/properties/name",
+                "type": "string"
+              }
+            }
+          }
+        },
         "repos": {
           "$id": "#/properties/dependencies/properties/repos",
           "type": "array",

--- a/walkthroughs/3-demo-walkthrough/walkthrough.adoc
+++ b/walkthroughs/3-demo-walkthrough/walkthrough.adoc
@@ -1,0 +1,5 @@
+= Title
+
+== Task
+
+=== Procedure

--- a/walkthroughs/3-demo-walkthrough/walkthrough.json
+++ b/walkthroughs/3-demo-walkthrough/walkthrough.json
@@ -1,0 +1,11 @@
+{
+  "dependencies": {
+    "repos": [],
+    "managedServices": [
+      {
+        "name": "amq-online-standard"
+      }
+    ],
+    "serviceInstances": []
+  }
+}


### PR DESCRIPTION
A change is being added to the web app to allow for a
managedServices configuration, this will be used to allow users to
specify which managed services in Integreatly they require for the
walkthrough.

This change updates the schema to allow for this new object along
with an example walkthrough.