### PR TITLE
[INTLY-2345] Update schema with templates array

### DIFF
--- a/bin/resources/schema.json
+++ b/bin/resources/schema.json
@@ -114,6 +114,25 @@
               }
             }
           }
+        },
+        "templates": {
+          "$id": "#/properties/dependencies/properties/templates",
+          "type": "array",
+          "title": "The Templates Schema",
+          "objects": {
+            "$id": "#/properties/dependencies/properties/templates/objects",
+            "type": "array",
+            "title": "The Objects Schema",
+            "required": [
+            ]
+          },
+          "parameters": {
+            "$id": "#/properties/dependencies/properties/templates/parameters",
+            "type": "array",
+            "title": "The Parameters Schema",
+            "required": [
+            ]
+          }
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-asciidoc",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Integreatly flavoured Asciidoc Parser",
   "main": "dist/bundle.web.js",
   "license": "Apache 2.0",

--- a/walkthroughs/1-demo-walkthrough/walkthrough.json
+++ b/walkthroughs/1-demo-walkthrough/walkthrough.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "repos": [],
-    "serviceInstances": []
+    "serviceInstances": [],
+    "templates": []
   }
 }


### PR DESCRIPTION
Update the schema with an additional option for Openshift templates that will be provisioned in the walkthrough namespace 

Jira: https://issues.jboss.org/browse/INTLY-2345
Walkthroughs pr: https://github.com/integr8ly/tutorial-web-app-walkthroughs/pull/87
Webapp pr: https://github.com/integr8ly/tutorial-web-app/pull/496